### PR TITLE
VAS-1816: add resource to request event object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@ Change Log
 
 Document the custom changes we made to the forked serverless webpack repository.
 
+### May 23, 2017 - rafat-accedo (1.0.0-rc.4-B)
+  - add resource to request.event object
+
 ### May 8, 2017 - rafat-accedo (1.0.0-rc.4-A)
   - support custom cors configuration in serverless.yml
 

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -114,7 +114,8 @@ module.exports = {
   },
 
   _handlerBase(funcConf, httpEvent) {
-    const isLambdaProxyIntegration = httpEvent && httpEvent.integration !== 'lambda'
+    const isLambdaProxyIntegration = httpEvent && httpEvent.integration !== 'lambda';
+    const resource = httpEvent ? '/' + httpEvent.path : '/';
 
     return (req, res) => {
       const func = funcConf.handlerFunc;
@@ -122,6 +123,7 @@ module.exports = {
         method: req.method,
         headers: req.headers,
         body: req.body,
+        resource: resource,
         [isLambdaProxyIntegration ? 'pathParameters' : 'path']: req.params,
         [isLambdaProxyIntegration ? 'queryStringParameters' : 'query']: req.query
         // principalId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-webpack",
-  "version": "1.0.0-rc.4-A",
+  "version": "1.0.0-rc.4-B",
   "description": "Serverless plugin to bundle your javascript with Webpack",
   "main": "index.js",
   "author": "Nicola Peduzzi <nicola.peduzzi@elastic-coders.com> (http://elastic-coders.com)",


### PR DESCRIPTION
Patrick's routing module requires the resource property (the api path) which is added by our custom velocity templates. However, serverless webpack doesn't read these templates and hence, our internal routing fails. This PR is a patch that adds the resource property to the request event object (without having to parse the velocity templates). With this PR, routing works with webpack serve.